### PR TITLE
resume aria2 downloading if interrupted on first attempt

### DIFF
--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -7,11 +7,11 @@ echo "########################################"
 set -euxo pipefail
 
 cd /home/runner
-git clone https://github.com/comfyanonymous/ComfyUI.git
+git clone https://github.com/comfyanonymous/ComfyUI.git || (cd /home/runner/ComfyUI && git pull)
 
 # Controlnet Preprocessor nodes by Fannovel16
 cd /home/runner/ComfyUI/custom_nodes
-git clone https://github.com/Fannovel16/comfy_controlnet_preprocessors
+git clone https://github.com/Fannovel16/comfy_controlnet_preprocessors || (cd /home/runner/ComfyUI/custom_nodes/comfy_controlnet_preprocessors && git pull)
 
 cd /home/runner/ComfyUI
 aria2c --allow-overwrite=false --auto-file-renaming=false --continue=true \


### PR DESCRIPTION
My interwebs died while this was downloading all the things, so I updated the download.sh to be able to get past the `git clone` step. It still requires to be manually triggered in the docker run command: 

```docker run -it --rm --name comfyui --gpus all -p 8188:8188 -v $PWD/storage:/home/runner --env CLI_ARGS="" yanwk/comfyui-boot:latest bash /home/scripts/download.sh```

The entrypoint could probably be updated to look at some other file than the main.py file of ComfyUI; maybe the download.sh creates an empty file `download-complete` or something after completion and `entrypoint.sh` runs `download.sh` if it doesn't exist.