### PR TITLE
🐛 fix: typo for python3 exe name

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -22,4 +22,4 @@ echo "########################################"
 
 cd /home/runner/ComfyUI
 
-python3 main.py --listen --port 8188 ${CLI_ARGS}
+python3.10 main.py --listen --port 8188 ${CLI_ARGS}


### PR DESCRIPTION
fixes #3 

it seems that the binary for python3.10 is not installed as `python3` but `python3.10` in the container