### PR TITLE
Add ability for pre-start script

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -10,6 +10,18 @@ if [ ! -f "/home/runner/.download-complete" ] ; then
     bash /home/scripts/download.sh
 fi ;
 
+if [ -f "/home/runner/scripts/pre-start.sh" ]; then
+    echo "########################################"
+    echo "Checking for pre-start script..."
+    echo "########################################"
+    
+    chmod +x /home/runner/scripts/pre-start.sh
+    bash /home/runner/scripts/pre-start.sh
+else
+    echo "No pre-start script found. Skipping."
+fi
+
+
 echo "########################################"
 echo "Starting ComfyUI..."
 echo "########################################"


### PR DESCRIPTION
This is a proposal to add the ability for users to further extend the image with their own custom startup scripts.

The startup script should be created by the user at `./storage/scripts/pre-start.sh`

My particular use case is to install some additional python packages for debugging, without needing to rebuild the whole image locally(Which for some reason fails.. but I haven't looked too deeply into that.)