### PR TITLE
Enable init process for main service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     command: "chown -R runner:runner /home/runner"
 
   comfyui:
+    init: true
     container_name: comfyui
     depends_on:
       file-chown:


### PR DESCRIPTION
Enables an init process for forwarding signals to the main service. This speeds up shutdown time when terminating via Ctrl + C

https://docs.docker.com/compose/compose-file/05-services/#init