### PR TITLE
Add compatible instructions for low end GPU and add users groups "video"

### DIFF
--- a/rocm/Dockerfile
+++ b/rocm/Dockerfile
@@ -94,6 +94,7 @@ RUN df -h \
 
 COPY runner-scripts/.  /runner-scripts/
 
+RUN groupadd -r video
 USER root
 VOLUME /root
 WORKDIR /root

--- a/rocm/README.adoc
+++ b/rocm/README.adoc
@@ -66,6 +66,12 @@ podman run -it --rm \
   yanwk/comfyui-boot:rocm
 ----
 
+Depends on the lower tiered AMD GPUs or your CPU with an integrated GPU (Ryzen 7000) then it may also require these extra configuration.
+
+- For RDNA and RDNA 2 cards, add this to "docker run" command above: `-e HSA_OVERRIDE_GFX_VERSION=10.3.0 \`
+- For RDNA 3 cards, add this to "docker run" command above:  `-e HSA_OVERRIDE_GFX_VERSION=11.0.0 \`
+- Integrated graphic on CPU, add this to "docker run" command above: `-e HIP_VISIBLE_DEVICES=0 \`
+
 Once the app is loaded, visit http://localhost:8188/
 
 [[hint]]

--- a/rocm/README.adoc
+++ b/rocm/README.adoc
@@ -66,11 +66,11 @@ podman run -it --rm \
   yanwk/comfyui-boot:rocm
 ----
 
-Depends on the lower tiered AMD GPUs or your CPU with an integrated GPU (Ryzen 7000) then it may also require these extra configuration.
+If you have lower tiered AMD GPUs or your CPU with an integrated GPU (Ryzen 7000) then you may need to add these configuration into the command of `docker run`, `podman run` above.
 
-- For RDNA and RDNA 2 cards, add this to "docker run" command above: `-e HSA_OVERRIDE_GFX_VERSION=10.3.0 \`
-- For RDNA 3 cards, add this to "docker run" command above:  `-e HSA_OVERRIDE_GFX_VERSION=11.0.0 \`
-- Integrated graphic on CPU, add this to "docker run" command above: `-e HIP_VISIBLE_DEVICES=0 \`
+- For RDNA and RDNA 2 cards: `-e HSA_OVERRIDE_GFX_VERSION=10.3.0 \`
+- For RDNA 3 cards:  `-e HSA_OVERRIDE_GFX_VERSION=11.0.0 \`
+- Integrated graphic on CPU: `-e HIP_VISIBLE_DEVICES=0 \`
 
 Once the app is loaded, visit http://localhost:8188/
 


### PR DESCRIPTION
This PR addresses two problems when I build and run on my Linux system. 

1. Error `docker: Error response from daemon: Unable to find group video: no matching entries in group file.`  This is fixed in Dockerfile.
2. Errror 
```
HIP error: invalid device function
HIP kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing AMD_SERIALIZE_KERNEL=3.
Compile with `TORCH_USE_HIP_DSA` to enable device-side assertions.
```
This can be fixed by adding proper configuration variables for ROCm GFX version. 