### PR TITLE
Added utils for cu128-megapak-pt29

### DIFF
--- a/cu128-megapak-pt29/Dockerfile
+++ b/cu128-megapak-pt29/Dockerfile
@@ -132,8 +132,6 @@ x264 \
 x265 \
 wget
 
-RUN rustup default stable
-
 RUN --mount=type=cache,target=/var/cache/zypp \
     zypper --non-interactive \
         install --force-resolution \
@@ -260,6 +258,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install \
 https://github.com/JamePeng/llama-cpp-python/releases/download/v0.3.18-cu128-AVX2-linux-20251220/llama_cpp_python-0.3.18-cp312-cp312-linux_x86_64.whl
 
+
 ################################################################################
 # Bundle ComfyUI in the image
 
@@ -287,6 +286,9 @@ RUN du -ah /root \
     && rm -rfv /root/.[^.]* /root/.??*
 
 COPY runner-scripts/.  /runner-scripts/
+
+# Setup default rustup toolchain
+RUN rustup default stable
 
 USER root
 VOLUME /root


### PR DESCRIPTION
Summary

This pull request adds the some tooling to the environment.

Changes

- Installed git-lfs for handling large files in the repository
- Installed wget for downloading external resources
- Installed the Rust toolchain
- Added torchcodec

Notes

- The Rust toolchain is required for building some Python packages and is fully installed and available in the environment.
- The default ffmpeg package available from the openSUSE repositories is too old for ``torchcodec``.
To enable full ``torchcodec`` functionality, ffmpeg must be upgraded to a newer version that meets the required constraints.

Reference:
https://github.com/meta-pytorch/torchcodec/blob/main/src/torchcodec/share/cmake/TorchCodec/ffmpeg_versions.cmake