### PR TITLE
Update pak7.txt

### DIFF
--- a/cu130-slim/builder-scripts/pak7.txt
+++ b/cu130-slim/builder-scripts/pak7.txt
@@ -1,7 +1,7 @@
 dlib
 facexlib
 insightface
-git+https://github.com/openai/CLIP.git
+git+https://github.com/StarTwi/CLIP.git@bb9d976819f587c37bd31b8fafe13358fcf8fdd7
 git+https://github.com/cozy-comfyui/cozy_comfyui@main#egg=cozy_comfyui
 git+https://github.com/cozy-comfyui/cozy_comfy@main#egg=cozy_comfy
 git+https://github.com/facebookresearch/sam2.git


### PR DESCRIPTION
using forked patched CLIP
Fixes #174

reviewing other references to
https://github.com/openai/CLIP/issues/528#event-22786528052

found
https://github.com/StarTwi/CLIP/commit/bb9d976819f587c37bd31b8fafe13358fcf8fdd7

changing pak7.txt to use this forked edit has tested in a successful build and functional UI with output
this change would be temporary until openai merges or a community accepted fork is established. 
