### PR TITLE
Revert Pak7 to openai CLIP now that fix is marged

### DIFF
--- a/cpu/builder-scripts/pak7.txt
+++ b/cpu/builder-scripts/pak7.txt
@@ -1,7 +1,7 @@
 dlib
 facexlib
 insightface
-git+https://github.com/StarTwi/CLIP.git@bb9d976819f587c37bd31b8fafe13358fcf8fdd7
+git+https://github.com/openai/CLIP.git
 git+https://github.com/cozy-comfyui/cozy_comfyui@main#egg=cozy_comfyui
 git+https://github.com/facebookresearch/sam2.git
 git+https://github.com/ltdrdata/cstr.git

--- a/cu126-megapak/builder-scripts/pak7.txt
+++ b/cu126-megapak/builder-scripts/pak7.txt
@@ -1,7 +1,7 @@
 dlib
 facexlib
 insightface
-git+https://github.com/StarTwi/CLIP.git@bb9d976819f587c37bd31b8fafe13358fcf8fdd7
+git+https://github.com/openai/CLIP.git
 git+https://github.com/cozy-comfyui/cozy_comfyui@main#egg=cozy_comfyui
 git+https://github.com/cozy-comfyui/cozy_comfy@main#egg=cozy_comfy
 git+https://github.com/ltdrdata/cstr.git

--- a/cu126-slim/builder-scripts/pak7.txt
+++ b/cu126-slim/builder-scripts/pak7.txt
@@ -1,7 +1,7 @@
 dlib
 facexlib
 insightface
-git+https://github.com/StarTwi/CLIP.git@bb9d976819f587c37bd31b8fafe13358fcf8fdd7
+git+https://github.com/openai/CLIP.git
 git+https://github.com/cozy-comfyui/cozy_comfyui@main#egg=cozy_comfyui
 git+https://github.com/cozy-comfyui/cozy_comfy@main#egg=cozy_comfy
 git+https://github.com/ltdrdata/cstr.git

--- a/cu128-megapak-pt28/builder-scripts/pak7.txt
+++ b/cu128-megapak-pt28/builder-scripts/pak7.txt
@@ -1,7 +1,7 @@
 dlib
 facexlib
 insightface
-git+https://github.com/StarTwi/CLIP.git@bb9d976819f587c37bd31b8fafe13358fcf8fdd7
+git+https://github.com/openai/CLIP.git
 git+https://github.com/cozy-comfyui/cozy_comfyui@main#egg=cozy_comfyui
 git+https://github.com/cozy-comfyui/cozy_comfy@main#egg=cozy_comfy
 git+https://github.com/ltdrdata/cstr.git

--- a/cu128-megapak-pt29/builder-scripts/pak7.txt
+++ b/cu128-megapak-pt29/builder-scripts/pak7.txt
@@ -1,7 +1,7 @@
 dlib
 facexlib
 insightface
-git+https://github.com/StarTwi/CLIP.git@bb9d976819f587c37bd31b8fafe13358fcf8fdd7
+git+https://github.com/openai/CLIP.git
 git+https://github.com/cozy-comfyui/cozy_comfyui@main#egg=cozy_comfyui
 git+https://github.com/cozy-comfyui/cozy_comfy@main#egg=cozy_comfy
 git+https://github.com/ltdrdata/cstr.git

--- a/cu128-megapak/builder-scripts/pak7.txt
+++ b/cu128-megapak/builder-scripts/pak7.txt
@@ -1,7 +1,7 @@
 dlib
 facexlib
 insightface
-git+https://github.com/StarTwi/CLIP.git@bb9d976819f587c37bd31b8fafe13358fcf8fdd7
+git+https://github.com/openai/CLIP.git
 git+https://github.com/cozy-comfyui/cozy_comfyui@main#egg=cozy_comfyui
 git+https://github.com/cozy-comfyui/cozy_comfy@main#egg=cozy_comfy
 git+https://github.com/ltdrdata/cstr.git

--- a/cu128-slim/builder-scripts/pak7.txt
+++ b/cu128-slim/builder-scripts/pak7.txt
@@ -1,7 +1,7 @@
 dlib
 facexlib
 insightface
-git+https://github.com/StarTwi/CLIP.git@bb9d976819f587c37bd31b8fafe13358fcf8fdd7
+git+https://github.com/openai/CLIP.git
 git+https://github.com/cozy-comfyui/cozy_comfyui@main#egg=cozy_comfyui
 git+https://github.com/cozy-comfyui/cozy_comfy@main#egg=cozy_comfy
 git+https://github.com/facebookresearch/sam2.git

--- a/cu130-slim/builder-scripts/pak7.txt
+++ b/cu130-slim/builder-scripts/pak7.txt
@@ -1,7 +1,7 @@
 dlib
 facexlib
 insightface
-git+https://github.com/StarTwi/CLIP.git@bb9d976819f587c37bd31b8fafe13358fcf8fdd7
+git+https://github.com/openai/CLIP.git
 git+https://github.com/cozy-comfyui/cozy_comfyui@main#egg=cozy_comfyui
 git+https://github.com/cozy-comfyui/cozy_comfy@main#egg=cozy_comfy
 git+https://github.com/facebookresearch/sam2.git

--- a/rocm/builder-scripts/pak7.txt
+++ b/rocm/builder-scripts/pak7.txt
@@ -1,7 +1,7 @@
 dlib
 facexlib
 insightface
-git+https://github.com/StarTwi/CLIP.git@bb9d976819f587c37bd31b8fafe13358fcf8fdd7
+git+https://github.com/openai/CLIP.git
 git+https://github.com/cozy-comfyui/cozy_comfyui@main#egg=cozy_comfyui
 git+https://github.com/ltdrdata/cstr.git
 git+https://github.com/ltdrdata/ffmpy.git

--- a/rocm6/builder-scripts/pak7.txt
+++ b/rocm6/builder-scripts/pak7.txt
@@ -1,7 +1,7 @@
 dlib
 facexlib
 insightface
-git+https://github.com/StarTwi/CLIP.git@bb9d976819f587c37bd31b8fafe13358fcf8fdd7
+git+https://github.com/openai/CLIP.git
 git+https://github.com/cozy-comfyui/cozy_comfyui@main#egg=cozy_comfyui
 git+https://github.com/ltdrdata/cstr.git
 git+https://github.com/ltdrdata/ffmpy.git

--- a/rocm7/builder-scripts/pak7.txt
+++ b/rocm7/builder-scripts/pak7.txt
@@ -1,7 +1,7 @@
 dlib
 facexlib
 insightface
-git+https://github.com/StarTwi/CLIP.git@bb9d976819f587c37bd31b8fafe13358fcf8fdd7
+git+https://github.com/openai/CLIP.git
 git+https://github.com/cozy-comfyui/cozy_comfyui@main#egg=cozy_comfyui
 git+https://github.com/ltdrdata/cstr.git
 git+https://github.com/ltdrdata/ffmpy.git


### PR DESCRIPTION
reverts #175 and continues fix for #174 from official package
StarTwi fix has been merged into openai official clip

ComfyUI-Docker should follow the main repo

this PR points the pak7 entry back to openai 
tested build of cu130-slim, runs and can output with CLIP in use.

confirmation of openai merge https://github.com/openai/CLIP/pull/529
